### PR TITLE
Dynamic names

### DIFF
--- a/src/main/java/net/kemitix/node/Node.java
+++ b/src/main/java/net/kemitix/node/Node.java
@@ -22,7 +22,8 @@ public interface Node<T> {
     String getName();
 
     /**
-     * Sets the explicit name for a node.
+     * Sets the explicit name for a node. Setting the name to null will clear
+     * the name and revert to the parent's name supplier.
      *
      * @param name the new name
      */

--- a/src/main/java/net/kemitix/node/Node.java
+++ b/src/main/java/net/kemitix/node/Node.java
@@ -14,7 +14,8 @@ import java.util.Set;
 public interface Node<T> {
 
     /**
-     * Fetch the name of the node.
+     * Fetch the name of the node. Where a node's name is determined via a name
+     * supplier, the name may be regenerated each time this method is called.
      *
      * @return the name of the node
      */
@@ -193,7 +194,8 @@ public interface Node<T> {
     String drawTree(int depth);
 
     /**
-     * Returns true if the Node has a name.
+     * Returns true if the Node has a name. Where a name supplier is used, the
+     * generated name is used.
      *
      * @return true if the node has a name
      */

--- a/src/main/java/net/kemitix/node/NodeItem.java
+++ b/src/main/java/net/kemitix/node/NodeItem.java
@@ -57,7 +57,6 @@ public class NodeItem<T> implements Node<T> {
             final T data, final Function<Node<T>, String> nameSupplier) {
         this(data);
         this.nameSupplier = nameSupplier;
-        name = generateName();
     }
 
     /**
@@ -69,7 +68,6 @@ public class NodeItem<T> implements Node<T> {
     public NodeItem(final T data, final Node<T> parent) {
         this.data = data;
         setParent(parent);
-        this.name = generateName();
     }
 
     /**
@@ -114,6 +112,9 @@ public class NodeItem<T> implements Node<T> {
 
     @Override
     public String getName() {
+        if (name == null) {
+            return generateName();
+        }
         return name;
     }
 
@@ -386,7 +387,8 @@ public class NodeItem<T> implements Node<T> {
 
     @Override
     public boolean isNamed() {
-        return name != null && name.length() > 0;
+        String currentName = getName();
+        return currentName != null && currentName.length() > 0;
     }
 
     @Override

--- a/src/test/java/net/kemitix/node/NodeItemTest.java
+++ b/src/test/java/net/kemitix/node/NodeItemTest.java
@@ -13,6 +13,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Test for {@link NodeItem}.
@@ -972,5 +973,30 @@ public class NodeItemTest {
         child.removeParent();
         //then
         assertThat(child.getName()).isEqualTo("local supplier");
+    }
+
+    @Test
+    public void getNameWithNameSupplierIsRecalculatedEachCall() {
+        val counter = new AtomicInteger(0);
+        node = new NodeItem<>(null,
+                n -> Integer.toString(counter.incrementAndGet()));
+        //then
+        assertThat(node.getName()).isNotEqualTo(node.getName());
+    }
+
+    @Test
+    public void isNamedWithNameSupplierIsRecalculatedEachCall() {
+        val counter = new AtomicInteger(0);
+        node = new NodeItem<>(null, n -> {
+            // alternate between even numbers and nulls: null, 2, null, 4, null
+            final int i = counter.incrementAndGet();
+            if (i % 2 == 0) {
+                return Integer.toString(i);
+            }
+            return null;
+        });
+        //then
+        assertThat(node.isNamed()).isFalse();
+        assertThat(node.isNamed()).isTrue();
     }
 }

--- a/src/test/java/net/kemitix/node/NodeItemTest.java
+++ b/src/test/java/net/kemitix/node/NodeItemTest.java
@@ -976,6 +976,18 @@ public class NodeItemTest {
     }
 
     @Test
+    public void setNameToNullRevertsToParentNameSupplier() {
+        //given
+        node = new NodeItem<>(null, n -> "root supplier");
+        val child = new NodeItem<String>(null, "child name", node);
+        assertThat(child.getName()).isEqualTo("child name");
+        //when
+        child.setName(null);
+        //then
+        assertThat(child.getName()).isEqualTo("root supplier");
+    }
+
+    @Test
     public void getNameWithNameSupplierIsRecalculatedEachCall() {
         val counter = new AtomicInteger(0);
         node = new NodeItem<>(null,


### PR DESCRIPTION
When using a name supplier the `getName()` method will regenerate the name on each call. Previously this name was only generated when the object is instantiated. If a name supplier wanted to use data from the node's parent or children, then this would quickly become out of date.

Now the following could be supported:

````
final Function<Node<String>, String> pathNameSupplier = node -> {
            Node<String> parent = node.getParent();
            if (parent == null) {
                return "";
            }
            return parent.getName() + "/" + node.getData();
        };