### PR TITLE
insertInPath() uses setData() to merge nodes

### DIFF
--- a/src/main/java/net/kemitix/node/NodeItem.java
+++ b/src/main/java/net/kemitix/node/NodeItem.java
@@ -333,9 +333,7 @@ public class NodeItem<T> implements Node<T> {
                 throw new NodeException(
                         "A non-empty node with that name already exists here");
             } else {
-                existing.getChildren().forEach(nodeItem::addChild);
-                existing.removeParent();
-                addChild(nodeItem);
+                existing.setData(nodeItem.getData());
             }
             return;
         }

--- a/src/test/java/net/kemitix/node/NodeItemTest.java
+++ b/src/test/java/net/kemitix/node/NodeItemTest.java
@@ -734,7 +734,9 @@ public class NodeItemTest {
         node.insertInPath(grandchild, "child");
         node.insertInPath(child);
         //then
-        assertThat(node.getChildByName("child")).as("child").isSameAs(child);
+        assertThat(node.getChildByName("child").getData()).as("data in tree")
+                                                          .isSameAs(
+                                                                  "child data");
         assertThat(
                 node.getChildByName("child").getChildByName("grandchild")).as(
                 "grandchild").isSameAs(grandchild);
@@ -798,14 +800,14 @@ public class NodeItemTest {
         child.addChild(target);
         final NodeItem<String> addMe = new NodeItem<>("I'm new", "target");
         assertThat(addMe.getParent()).isNull();
+        assertThat(child.getChildByName("target").isEmpty()).as(
+                "target starts empty").isTrue();
         //when
         // addMe should replace target as the sole descendant of child
         node.insertInPath(addMe, "child");
         //then
-        assertThat(child.getChildren()).as("child only contains new node")
-                                       .containsOnly(addMe);
-        assertThat(target.getParent()).as("old node is removed from tree")
-                                      .isNull();
+        assertThat(child.getChildByName("target").getData()).as(
+                "target now contains data").isEqualTo("I'm new");
     }
 
     @Test


### PR DESCRIPTION
When a node is being added to a tree where there is already an empty in place, the new node is no longer swapping in to replace it. Now the data from the node is added to the existing node.