### PR TITLE
Static factory constructors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <properties>
         <assertj.version>3.4.1</assertj.version>
         <coveralls-maven-plugin.version>4.2.0</coveralls-maven-plugin.version>
+        <trajano-commons-testing.version>2.1.0</trajano-commons-testing.version>
     </properties>
 
     <issueManagement>
@@ -67,6 +68,12 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.trajano.commons</groupId>
+            <artifactId>commons-testing</artifactId>
+            <version>${trajano-commons-testing.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/net/kemitix/node/NodeItem.java
+++ b/src/main/java/net/kemitix/node/NodeItem.java
@@ -32,7 +32,7 @@ public class NodeItem<T> implements Node<T> {
      * @param data the data or null
      * @param name the name
      */
-    public NodeItem(final T data, final String name) {
+    NodeItem(final T data, final String name) {
         this(data);
         this.name = name;
     }
@@ -42,7 +42,7 @@ public class NodeItem<T> implements Node<T> {
      *
      * @param data the data or null
      */
-    public NodeItem(final T data) {
+    NodeItem(final T data) {
         this.data = data;
         this.nameSupplier = (n) -> null;
     }
@@ -68,7 +68,7 @@ public class NodeItem<T> implements Node<T> {
      * @param data   the data or null
      * @param parent the parent node
      */
-    public NodeItem(final T data, final Node<T> parent) {
+    NodeItem(final T data, final Node<T> parent) {
         this.data = data;
         setParent(parent);
     }
@@ -80,7 +80,7 @@ public class NodeItem<T> implements Node<T> {
      * @param name   the name
      * @param parent the parent node
      */
-    public NodeItem(final T data, final String name, final Node<T> parent) {
+    NodeItem(final T data, final String name, final Node<T> parent) {
         this.data = data;
         this.name = name;
         setParent(parent);

--- a/src/main/java/net/kemitix/node/NodeItem.java
+++ b/src/main/java/net/kemitix/node/NodeItem.java
@@ -235,6 +235,7 @@ public class NodeItem<T> implements Node<T> {
      * @return the found or created child node
      */
     @Override
+    @Deprecated
     public Node<T> findOrCreateChild(final T child) {
         if (child == null) {
             throw new NullPointerException("child");

--- a/src/main/java/net/kemitix/node/NodeItem.java
+++ b/src/main/java/net/kemitix/node/NodeItem.java
@@ -48,21 +48,6 @@ public class NodeItem<T> implements Node<T> {
     }
 
     /**
-     * Creates root node with a name supplier.
-     *
-     * @param data         the data or null
-     * @param nameSupplier the name supplier function
-     *
-     * @deprecated dynamic names don't work on immutable objects
-     */
-    @Deprecated
-    public NodeItem(
-            final T data, final Function<Node<T>, String> nameSupplier) {
-        this(data);
-        this.nameSupplier = nameSupplier;
-    }
-
-    /**
      * Creates a node with a parent.
      *
      * @param data   the data or null
@@ -83,23 +68,6 @@ public class NodeItem<T> implements Node<T> {
     NodeItem(final T data, final String name, final Node<T> parent) {
         this.data = data;
         this.name = name;
-        setParent(parent);
-    }
-
-    /**
-     * Creates a node with a name supplier and a parent.
-     *
-     * @param data         the data or null
-     * @param nameSupplier the name supplier function
-     * @param parent       the parent node
-     *
-     * @deprecated dynamic names don't work on immutable objects
-     */
-    @Deprecated
-    public NodeItem(
-            final T data, final Function<Node<T>, String> nameSupplier,
-            final Node<T> parent) {
-        this(data, nameSupplier);
         setParent(parent);
     }
 

--- a/src/main/java/net/kemitix/node/NodeItem.java
+++ b/src/main/java/net/kemitix/node/NodeItem.java
@@ -255,10 +255,10 @@ public class NodeItem<T> implements Node<T> {
         if (child == null) {
             throw new NullPointerException("child");
         }
-        return children.stream()
-                       .filter(n -> !n.isEmpty())
-                       .filter(n -> n.getData().get().equals(child))
-                       .findAny();
+        return children.stream().filter(node -> {
+            final Optional<T> d = node.getData();
+            return d.isPresent() && d.get().equals(child);
+        }).findAny();
     }
 
     @Override

--- a/src/main/java/net/kemitix/node/NodeItem.java
+++ b/src/main/java/net/kemitix/node/NodeItem.java
@@ -52,7 +52,10 @@ public class NodeItem<T> implements Node<T> {
      *
      * @param data         the data or null
      * @param nameSupplier the name supplier function
+     *
+     * @deprecated dynamic names don't work on immutable objects
      */
+    @Deprecated
     public NodeItem(
             final T data, final Function<Node<T>, String> nameSupplier) {
         this(data);
@@ -89,7 +92,10 @@ public class NodeItem<T> implements Node<T> {
      * @param data         the data or null
      * @param nameSupplier the name supplier function
      * @param parent       the parent node
+     *
+     * @deprecated dynamic names don't work on immutable objects
      */
+    @Deprecated
     public NodeItem(
             final T data, final Function<Node<T>, String> nameSupplier,
             final Node<T> parent) {

--- a/src/main/java/net/kemitix/node/Nodes.java
+++ b/src/main/java/net/kemitix/node/Nodes.java
@@ -1,0 +1,66 @@
+package net.kemitix.node;
+
+/**
+ * Utility class for {@link Node} items.
+ *
+ * @author pcampbell
+ */
+public final class Nodes {
+
+    private Nodes() {
+    }
+
+    /**
+     * Creates a new unnamed root node.
+     *
+     * @param data the data the node will contain
+     * @param <T>  the type of the data
+     *
+     * @return the new node
+     */
+    public static <T> Node<T> unnamedRoot(final T data) {
+        return new NodeItem<>(data);
+    }
+
+    /**
+     * Creates a new named root node.
+     *
+     * @param data the data the node will contain
+     * @param name the name of the node
+     * @param <T>  the type of the data
+     *
+     * @return the new node
+     */
+    public static <T> Node<T> namedRoot(final T data, final String name) {
+        return new NodeItem<>(data, name);
+    }
+
+    /**
+     * Creates a new unnamed child node.
+     *
+     * @param data   the data the node will contain
+     * @param parent the parent of the node
+     * @param <T>    the type of the data
+     *
+     * @return the new node
+     */
+    public static <T> Node<T> unnamedChild(final T data, final Node<T> parent) {
+        return new NodeItem<>(data, parent);
+    }
+
+    /**
+     * Creates a new named child node.
+     *
+     * @param data   the data the node will contain
+     *               @param name the name of the node
+     * @param parent the parent of the node
+     * @param <T>    the type of the data
+     *
+     * @return the new node
+     */
+    public static <T> Node<T> namedChild(
+            final T data, final String name, final Node<T> parent) {
+        return new NodeItem<>(data, name, parent);
+    }
+
+}

--- a/src/test/java/net/kemitix/node/NodeItemTest.java
+++ b/src/test/java/net/kemitix/node/NodeItemTest.java
@@ -33,7 +33,7 @@ public class NodeItemTest {
         //given
         val data = "this node data";
         //when
-        node = new NodeItem<>(data);
+        node = Nodes.unnamedRoot(data);
         //then
         assertThat(node.getData()).as("can get the data from a node").
                 contains(data);
@@ -42,7 +42,7 @@ public class NodeItemTest {
     @Test
     public void canCreateAnEmptyAndUnnamedNode() {
         //when
-        node = new NodeItem<>(null);
+        node = Nodes.unnamedRoot(null);
         //then
         SoftAssertions softly = new SoftAssertions();
         softly.assertThat(node.isEmpty()).as("node is empty").isTrue();
@@ -64,7 +64,7 @@ public class NodeItemTest {
     @Test
     public void canSetName() {
         //given
-        node = new NodeItem<>(null);
+        node = Nodes.unnamedRoot(null);
         //when
         node.setName("named");
         //then
@@ -77,7 +77,7 @@ public class NodeItemTest {
     @Test
     public void shouldHaveNullForDefaultParent() {
         //given
-        node = new NodeItem<>("data");
+        node = Nodes.unnamedRoot("data");
         //then
         assertThat(node.getParent()).as(
                 "node created without a parent has no parent").isEmpty();
@@ -89,9 +89,9 @@ public class NodeItemTest {
     @Test
     public void shouldReturnNodeParent() {
         //given
-        val parent = new NodeItem<String>("parent");
+        val parent = Nodes.unnamedRoot("parent");
         //when
-        node = new NodeItem<>("subject", parent);
+        node = Nodes.unnamedChild("subject", parent);
         //then
         assertThat(node.getParent()).as(
                 "node created with a parent can return the parent")
@@ -105,8 +105,8 @@ public class NodeItemTest {
     @Test
     public void setParentShouldThrowNodeExceptionWhenParentIsAChild() {
         //given
-        node = new NodeItem<>("subject");
-        val child = new NodeItem<String>("child", node);
+        node = Nodes.unnamedRoot("subject");
+        val child = Nodes.unnamedChild("child", node);
         exception.expect(NodeException.class);
         exception.expectMessage("Parent is a descendant");
         //when
@@ -121,9 +121,9 @@ public class NodeItemTest {
     @SuppressWarnings("unchecked")
     public void shouldAddNewNodeAsChildToParent() {
         //given
-        val parent = new NodeItem<String>("parent");
+        val parent = Nodes.unnamedRoot("parent");
         //when
-        node = new NodeItem<>("subject", parent);
+        node = Nodes.unnamedChild("subject", parent);
         //then
         assertThat(parent.getChildren()).as(
                 "when a node is created with a parent, the parent has the new"
@@ -136,8 +136,8 @@ public class NodeItemTest {
     @Test
     public void shouldReturnSetParent() {
         //given
-        node = new NodeItem<>("subject");
-        val parent = new NodeItem<String>("parent");
+        node = Nodes.unnamedRoot("subject");
+        val parent = Nodes.unnamedRoot("parent");
         //when
         node.setParent(parent);
         //then
@@ -152,7 +152,7 @@ public class NodeItemTest {
     @Test
     public void shouldThrowNPEWhenSetParentNull() {
         //given
-        node = new NodeItem<>("subject");
+        node = Nodes.unnamedRoot("subject");
         exception.expect(NullPointerException.class);
         exception.expectMessage("parent");
         //when
@@ -166,7 +166,7 @@ public class NodeItemTest {
     @Test
     public void setParentShouldThrowNodeExceptionWhenParentIsSelf() {
         //given
-        node = new NodeItem<>("subject");
+        node = Nodes.unnamedRoot("subject");
         exception.expect(NodeException.class);
         exception.expectMessage("Parent is a descendant");
         //when
@@ -180,9 +180,9 @@ public class NodeItemTest {
     @Test
     public void shouldUpdateOldParentWhenNodeSetToNewParent() {
         //given
-        node = new NodeItem<>("subject");
+        node = Nodes.unnamedRoot("subject");
         val child = node.createChild("child");
-        val newParent = new NodeItem<String>("newParent");
+        val newParent = Nodes.unnamedRoot("newParent");
         //when
         child.setParent(newParent);
         //then
@@ -201,9 +201,9 @@ public class NodeItemTest {
     @Test
     public void shouldRemoveNodeFromOldParentWhenAddedAsChildToNewParent() {
         //given
-        node = new NodeItem<>("subject");
+        node = Nodes.unnamedRoot("subject");
         val child = node.createChild("child");
-        val newParent = new NodeItem<String>("newParent");
+        val newParent = Nodes.unnamedRoot("newParent");
         //when
         newParent.addChild(child);
         //then
@@ -223,7 +223,7 @@ public class NodeItemTest {
     @Test
     public void shouldThrowNPEWhenAddingNullAsChild() {
         //given
-        node = new NodeItem<>("subject");
+        node = Nodes.unnamedRoot("subject");
         exception.expect(NullPointerException.class);
         exception.expectMessage("child");
         //when
@@ -237,8 +237,8 @@ public class NodeItemTest {
     @SuppressWarnings("unchecked")
     public void shouldReturnAddedChild() {
         //given
-        node = new NodeItem<>("subject");
-        val child = new NodeItem<String>("child");
+        node = Nodes.unnamedRoot("subject");
+        val child = Nodes.unnamedRoot("child");
         //when
         node.addChild(child);
         //then
@@ -253,7 +253,7 @@ public class NodeItemTest {
     @Test
     public void addChildShouldThrowNodeExceptionWhenAddingANodeAsOwnChild() {
         //given
-        node = new NodeItem<>("subject");
+        node = Nodes.unnamedRoot("subject");
         exception.expect(NodeException.class);
         exception.expectMessage("Child is an ancestor");
         //then
@@ -266,7 +266,7 @@ public class NodeItemTest {
     @Test
     public void addChildShouldThrowNodeExceptionWhenAddingSelfAsChild() {
         //given
-        node = new NodeItem<>("subject");
+        node = Nodes.unnamedRoot("subject");
         exception.expect(NodeException.class);
         exception.expectMessage("Child is an ancestor");
         //when
@@ -280,8 +280,8 @@ public class NodeItemTest {
     @Test
     public void addChildShouldThrowNodeExceptionWhenChildIsParent() {
         //given
-        val parent = new NodeItem<String>("parent");
-        node = new NodeItem<>("subject", parent);
+        val parent = Nodes.unnamedRoot("parent");
+        node = Nodes.unnamedChild("subject", parent);
         exception.expect(NodeException.class);
         exception.expectMessage("Child is an ancestor");
         //when
@@ -295,9 +295,9 @@ public class NodeItemTest {
     @Test
     public void addChildShouldThrowNodeExceptionWhenAddingGrandParentAsChild() {
         //given
-        val grandParent = new NodeItem<String>("grandparent");
-        val parent = new NodeItem<String>("parent", grandParent);
-        node = new NodeItem<>("subject", parent);
+        val grandParent = Nodes.unnamedRoot("grandparent");
+        val parent = Nodes.unnamedChild("parent", grandParent);
+        node = Nodes.unnamedChild("subject", parent);
         exception.expect(NodeException.class);
         exception.expectMessage("Child is an ancestor");
         //when
@@ -310,8 +310,8 @@ public class NodeItemTest {
     @Test
     public void shouldSetParentOnChildWhenAddedAsChild() {
         //given
-        node = new NodeItem<>("subject");
-        val child = new NodeItem<String>("child");
+        node = Nodes.unnamedRoot("subject");
+        val child = Nodes.unnamedRoot("child");
         //when
         node.addChild(child);
         //then
@@ -327,11 +327,11 @@ public class NodeItemTest {
     public void shouldWalkTreeToNode() {
         //given
         val grandparent = "grandparent";
-        val grandParentNode = new NodeItem<String>(grandparent);
+        val grandParentNode = Nodes.unnamedRoot(grandparent);
         val parent = "parent";
-        val parentNode = new NodeItem<String>(parent, grandParentNode);
+        val parentNode = Nodes.unnamedChild(parent, grandParentNode);
         val subject = "subject";
-        node = new NodeItem<>(subject, parentNode);
+        node = Nodes.unnamedChild(subject, parentNode);
         //when
         val result = grandParentNode.findInPath(Arrays.asList(parent, subject));
         //then
@@ -352,9 +352,9 @@ public class NodeItemTest {
     public void shouldNotFindNonExistentChildNode() {
         //given
         val parent = "parent";
-        val parentNode = new NodeItem<String>(parent);
+        val parentNode = Nodes.unnamedRoot(parent);
         val subject = "subject";
-        node = new NodeItem<>(subject, parentNode);
+        node = Nodes.unnamedChild(subject, parentNode);
         //when
         val result = parentNode.findInPath(Arrays.asList(subject, "no child"));
         //then
@@ -369,7 +369,7 @@ public class NodeItemTest {
     @Test
     public void shouldThrowNEWhenWalkTreeNull() {
         //given
-        node = new NodeItem<>("subject");
+        node = Nodes.unnamedRoot("subject");
         exception.expect(NullPointerException.class);
         exception.expectMessage("path");
         //when
@@ -383,7 +383,7 @@ public class NodeItemTest {
     @Test
     public void shouldReturnEmptyForEmptyWalkTreePath() {
         //given
-        node = new NodeItem<>("subject");
+        node = Nodes.unnamedRoot("subject");
         //when
         val result = node.findInPath(Collections.emptyList());
         //then
@@ -396,7 +396,7 @@ public class NodeItemTest {
     @Test
     public void shouldCreateDescendantNodes() {
         //given
-        node = new NodeItem<>("subject");
+        node = Nodes.unnamedRoot("subject");
         val alphaData = "alpha";
         val betaData = "beta";
         val gammaData = "gamma";
@@ -445,7 +445,7 @@ public class NodeItemTest {
     @Test
     public void createDescendantLineShouldThrowNPEWhenDescendantsAreNull() {
         //given
-        node = new NodeItem<>("subject");
+        node = Nodes.unnamedRoot("subject");
         exception.expect(NullPointerException.class);
         exception.expectMessage("descendants");
         //when
@@ -458,7 +458,7 @@ public class NodeItemTest {
     @Test
     public void shouldChangeNothingWhenCreateDescendantEmpty() {
         //given
-        node = new NodeItem<>("subject");
+        node = Nodes.unnamedRoot("subject");
         //when
         node.createDescendantLine(Collections.emptyList());
         //then
@@ -473,9 +473,9 @@ public class NodeItemTest {
     @Test
     public void shouldFindExistingChildNode() {
         //given
-        node = new NodeItem<>("subject");
+        node = Nodes.unnamedRoot("subject");
         val childData = "child";
-        val child = new NodeItem<String>(childData, node);
+        val child = Nodes.unnamedChild(childData, node);
         //when
         val found = node.findOrCreateChild(childData);
         //then
@@ -490,7 +490,7 @@ public class NodeItemTest {
     @Test
     public void shouldFindCreateNewChildNode() {
         //given
-        node = new NodeItem<>("subject");
+        node = Nodes.unnamedRoot("subject");
         val childData = "child";
         //when
         val found = node.findOrCreateChild(childData);
@@ -506,7 +506,7 @@ public class NodeItemTest {
     @Test
     public void findOrCreateChildShouldThrowNPEFWhenChildIsNull() {
         //given
-        node = new NodeItem<>("subject");
+        node = Nodes.unnamedRoot("subject");
         exception.expect(NullPointerException.class);
         exception.expectMessage("child");
         //when
@@ -519,9 +519,9 @@ public class NodeItemTest {
     @Test
     public void shouldGetChild() {
         //given
-        node = new NodeItem<>("subject");
+        node = Nodes.unnamedRoot("subject");
         val childData = "child";
-        val child = new NodeItem<String>(childData);
+        val child = Nodes.unnamedRoot(childData);
         node.addChild(child);
         //when
         val found = node.findChild(childData);
@@ -541,7 +541,7 @@ public class NodeItemTest {
     @Test
     public void getChildShouldThrowNPEWhenThereIsNoChild() {
         //given
-        node = new NodeItem<>("data");
+        node = Nodes.unnamedRoot("data");
         exception.expect(NullPointerException.class);
         exception.expectMessage("child");
         //when
@@ -555,7 +555,7 @@ public class NodeItemTest {
     @Test
     public void shouldCreateChild() {
         //given
-        node = new NodeItem<>("subject");
+        node = Nodes.unnamedRoot("subject");
         val childData = "child";
         //when
         val child = node.createChild(childData);
@@ -580,7 +580,7 @@ public class NodeItemTest {
     @Test
     public void createChildShouldThrowNPEWhenChildIsNull() {
         //given
-        node = new NodeItem<>("subject");
+        node = Nodes.unnamedRoot("subject");
         exception.expect(NullPointerException.class);
         exception.expectMessage("child");
         //when
@@ -599,7 +599,7 @@ public class NodeItemTest {
     public void getNameShouldUseParentNameSupplier() {
         //given
         val root = new NodeItem<String>("root", n -> n.getData().get());
-        node = new NodeItem<>("child", root);
+        node = Nodes.unnamedChild("child", root);
         //then
         assertThat(node.getName()).isEqualTo("child");
     }
@@ -622,7 +622,7 @@ public class NodeItemTest {
         node = new NodeItem<>("root", n -> n.getData().get());
         val child = new NodeItem<String>("child", Object::toString);
         node.addChild(child);
-        val grandChild = new NodeItem<>("grandchild", child);
+        val grandChild = Nodes.unnamedChild("grandchild", child);
         //then
         assertThat(node.getName()).isEqualTo("root");
         assertThat(child.getName()).isNotEqualTo("child");
@@ -631,8 +631,8 @@ public class NodeItemTest {
 
     @Test
     public void getNameShouldWorkWithoutNameSupplier() {
-        node = new NodeItem<>(null, "root");
-        val namedchild = new NodeItem<>("named", "Alice", node);
+        node = Nodes.namedRoot(null, "root");
+        val namedchild = Nodes.namedChild("named", "Alice", node);
         //then
         assertThat(node.getName()).isEqualTo("root");
         assertThat(namedchild.getName()).isEqualTo("Alice");
@@ -640,22 +640,22 @@ public class NodeItemTest {
 
     @Test
     public void canCreateRootNodeWithoutData() {
-        node = new NodeItem<>(null, "empty");
+        node = Nodes.namedRoot(null, "empty");
         assertThat(node.getData()).isEmpty();
     }
 
     @Test
     public void canCreateRootNodeWithoutDataButWithNameSupplier() {
-        node = new NodeItem<>(null);
+        node = Nodes.unnamedRoot(null);
         assertThat(node.getData()).isEmpty();
     }
 
     @Test
     public void getChildNamedFindsChild() {
         //given
-        node = new NodeItem<>(null, "root");
-        val alpha = new NodeItem<String>(null, "alpha");
-        val beta = new NodeItem<String>(null, "beta");
+        node = Nodes.namedRoot("root data", "root");
+        val alpha = Nodes.namedRoot("alpha data", "alpha");
+        val beta = Nodes.namedRoot("beta data", "beta");
         node.addChild(alpha);
         node.addChild(beta);
         //when
@@ -667,9 +667,9 @@ public class NodeItemTest {
     @Test
     public void getChildNamedFindsNothing() {
         //given
-        node = new NodeItem<>(null, "root");
-        val alpha = new NodeItem<String>(null, "alpha");
-        val beta = new NodeItem<String>(null, "beta");
+        node = Nodes.namedRoot("root data", "root");
+        val alpha = Nodes.namedRoot("alpha data", "alpha");
+        val beta = Nodes.namedRoot("beta data", "beta");
         node.addChild(alpha);
         node.addChild(beta);
         exception.expect(NodeException.class);
@@ -681,10 +681,10 @@ public class NodeItemTest {
     @Test
     public void nodeNamesAreUniqueWithinAParent() {
         //given
-        node = new NodeItem<>(null, "root");
-        val alpha = new NodeItem<String>(null, "alpha");
+        node = Nodes.namedRoot("root data", "root");
+        val alpha = Nodes.namedRoot("alpha data", "alpha");
         node.addChild(alpha);
-        val beta = new NodeItem<String>(null, "alpha");
+        val beta = Nodes.namedRoot("beta data", "alpha");
         exception.expect(NodeException.class);
         exception.expectMessage("Node with that name already exists here");
         //when
@@ -694,8 +694,8 @@ public class NodeItemTest {
     @Test
     public void canPlaceNodeInTreeByPathNames() {
         //given
-        node = new NodeItem<>(null, "root"); // create a root
-        val four = new NodeItem<String>("data", "four");
+        node = Nodes.namedRoot("root data", "root"); // create a root
+        val four = Nodes.namedRoot("data", "four");
         //when
         node.insertInPath(four, "one", "two", "three");
         //then
@@ -717,9 +717,9 @@ public class NodeItemTest {
     @SuppressWarnings("unchecked")
     public void canPlaceInTreeUnderExistingNode() {
         //given
-        node = new NodeItem<>(null, "root");
-        val child = new NodeItem<String>("child data", "child");
-        val grandchild = new NodeItem<String>("grandchild data", "grandchild");
+        node = Nodes.namedRoot(null, "root");
+        val child = Nodes.namedRoot("child data", "child");
+        val grandchild = Nodes.namedRoot("grandchild data", "grandchild");
         //when
         node.insertInPath(child); // as root/child
         node.insertInPath(grandchild, "child"); // as root/child/grandchild
@@ -734,9 +734,9 @@ public class NodeItemTest {
     @SuppressWarnings("unchecked")
     public void canPlaceInTreeAboveExistingNode() {
         //given
-        node = new NodeItem<>(null, "root");
-        val child = new NodeItem<String>("child data", "child");
-        val grandchild = new NodeItem<String>("grandchild data", "grandchild");
+        node = Nodes.namedRoot(null, "root");
+        val child = Nodes.namedRoot("child data", "child");
+        val grandchild = Nodes.namedRoot("grandchild data", "grandchild");
         //when
         node.insertInPath(grandchild, "child");
         node.insertInPath(child);
@@ -752,7 +752,7 @@ public class NodeItemTest {
     @Test
     public void removingParentFromNodeWithNoParentIsNoop() {
         //given
-        node = new NodeItem<>(null);
+        node = Nodes.unnamedRoot(null);
         //when
         node.removeParent();
     }
@@ -760,8 +760,8 @@ public class NodeItemTest {
     @Test
     public void removingParentFromNodeWithParentRemovesParent() {
         //given
-        node = new NodeItem<>(null);
-        val child = new NodeItem<String>(null, node);
+        node = Nodes.unnamedRoot(null);
+        val child = Nodes.unnamedChild("child data", node);
         //when
         child.removeParent();
         //then
@@ -775,22 +775,22 @@ public class NodeItemTest {
         exception.expect(NodeException.class);
         exception.expectMessage(
                 "A non-empty node named 'grandchild' already exists here");
-        node = new NodeItem<>(null);
-        val child = new NodeItem<String>(null, "child", node);
-        new NodeItem<>("data", "grandchild", child);
+        node = Nodes.unnamedRoot(null);
+        val child = Nodes.namedChild("child data", "child", node);
+        Nodes.namedChild("data", "grandchild", child);
         // root -> child -> grandchild
         // only grandchild has data
         //when
         // attempt to add another node called 'grandchild' to 'child'
-        node.insertInPath(new NodeItem<>("cuckoo", "grandchild"), "child");
+        node.insertInPath(Nodes.namedRoot("cuckoo", "grandchild"), "child");
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void placeNodeInTreeWhenAddedNodeIsUnnamed() {
         //given
-        node = new NodeItem<>(null);
-        final Node<String> newNode = new NodeItem<>(null);
+        node = Nodes.unnamedRoot(null);
+        final Node<String> newNode = Nodes.unnamedRoot(null);
         //when
         node.insertInPath(newNode);
         //then
@@ -801,12 +801,12 @@ public class NodeItemTest {
     @SuppressWarnings("unchecked")
     public void placeNodeInTreeWhenEmptyChildWithTargetNameExists() {
         //given
-        node = new NodeItem<>(null);
-        final NodeItem<String> child = new NodeItem<>(null, "child");
-        final NodeItem<String> target = new NodeItem<>(null, "target");
+        node = Nodes.unnamedRoot(null);
+        final Node<String> child = Nodes.namedRoot(null, "child");
+        final Node<String> target = Nodes.namedRoot(null, "target");
         node.addChild(child);
         child.addChild(target);
-        final NodeItem<String> addMe = new NodeItem<>("I'm new", "target");
+        val addMe = Nodes.namedRoot("I'm new", "target");
         assertThat(addMe.getParent()).isEmpty();
         assertThat(child.getChildByName("target").isEmpty()).as(
                 "target starts empty").isTrue();
@@ -823,7 +823,7 @@ public class NodeItemTest {
         //given
         exception.expect(NullPointerException.class);
         exception.expectMessage("name");
-        node = new NodeItem<>(null);
+        node = Nodes.unnamedRoot(null);
         //when
         node.findChildByName(null);
     }
@@ -831,7 +831,7 @@ public class NodeItemTest {
     @Test
     public void isNamedNull() {
         //given
-        node = new NodeItem<>(null);
+        node = Nodes.unnamedRoot(null);
         //then
         assertThat(node.isNamed()).isFalse();
     }
@@ -839,7 +839,7 @@ public class NodeItemTest {
     @Test
     public void isNamedEmpty() {
         //given
-        node = new NodeItem<>(null, "");
+        node = Nodes.namedRoot(null, "");
         //then
         assertThat(node.isNamed()).isFalse();
     }
@@ -847,7 +847,7 @@ public class NodeItemTest {
     @Test
     public void isNamedNamed() {
         //given
-        node = new NodeItem<>(null, "named");
+        node = Nodes.namedRoot(null, "named");
         //then
         assertThat(node.isNamed()).isTrue();
     }
@@ -858,7 +858,7 @@ public class NodeItemTest {
         // provider
         //given
         node = new NodeItem<>("data", n -> n.getData().get());
-        final NodeItem<String> child = new NodeItem<>("other", node);
+        val child = Nodes.unnamedChild("other", node);
         assertThat(node.getName()).as("initial root name").isEqualTo("data");
         assertThat(child.getName()).as("initial child name").isEqualTo("other");
         //when
@@ -872,7 +872,7 @@ public class NodeItemTest {
     @SuppressWarnings("unchecked")
     public void removeChildRemovesTheChild() {
         //given
-        node = new NodeItem<>(null);
+        node = Nodes.unnamedRoot(null);
         Node<String> child = node.createChild("child");
         assertThat(node.getChildren()).containsExactly(child);
         //then
@@ -885,13 +885,14 @@ public class NodeItemTest {
     @Test
     public void drawTreeIsCorrect() {
         //given
-        node = new NodeItem<>(null, "root");
-        val bob = new NodeItem<String>(null, "bob", node);
-        val alice = new NodeItem<String>(null, "alice", node);
-        new NodeItem<>(null, "dave", alice);
-        new NodeItem<>(null, bob); // has no name and no children so no included
-        val kim = new NodeItem<String>(null, node); // nameless mother
-        new NodeItem<>(null, "lucy", kim);
+        node = Nodes.namedRoot(null, "root");
+        val bob = Nodes.namedChild("bob data", "bob", node);
+        val alice = Nodes.namedChild("alice data", "alice", node);
+        Nodes.namedChild("dave data", "dave", alice);
+        Nodes.unnamedChild("bob's child's data",
+                bob); // has no name and no children so no included
+        val kim = Nodes.unnamedChild("kim data", node); // nameless mother
+        Nodes.namedChild("lucy data", "lucy", kim);
         //when
         val tree = node.drawTree(0);
         //then
@@ -907,7 +908,7 @@ public class NodeItemTest {
     @Test
     public void canChangeNodeData() {
         //given
-        node = new NodeItem<>("initial");
+        node = Nodes.unnamedRoot("initial");
         //when
         node.setData("updated");
         //then
@@ -918,7 +919,7 @@ public class NodeItemTest {
     @SuppressWarnings("unchecked")
     public void canCreateNamedChild() {
         //given
-        node = new NodeItem<>(null);
+        node = Nodes.unnamedRoot(null);
         //when
         Node<String> child = node.createChild("child data", "child name");
         //then
@@ -930,10 +931,10 @@ public class NodeItemTest {
     @Test
     public void canGetChildWhenFound() {
         //given
-        node = new NodeItem<>("data");
-        Node<String> child = new NodeItem<>("child data", "child name", node);
+        node = Nodes.unnamedRoot("data");
+        val child = Nodes.namedChild("child data", "child name", node);
         //when
-        Node<String> found = node.getChild("child data");
+        val found = node.getChild("child data");
         //then
         assertThat(found).isSameAs(child);
     }
@@ -943,7 +944,7 @@ public class NodeItemTest {
         //given
         exception.expect(NodeException.class);
         exception.expectMessage("Child not found");
-        node = new NodeItem<>("data");
+        node = Nodes.unnamedRoot("data");
         //when
         node.getChild("child data");
     }
@@ -952,9 +953,9 @@ public class NodeItemTest {
     @SuppressWarnings("unchecked")
     public void constructorWithNameSupplierAndParentBeChildOfParent() {
         //given
-        node = new NodeItem<>(null);
+        node = Nodes.unnamedRoot(null);
         //when
-        NodeItem<String> child = new NodeItem<>(null, node);
+        val child = Nodes.unnamedChild("child data", node);
         //then
         assertThat(child.getParent()).contains(node);
         assertThat(node.getChildren()).containsExactly(child);
@@ -965,7 +966,7 @@ public class NodeItemTest {
     public void removeParentCopiesRootNameSupplier() {
         //given
         node = new NodeItem<>("root data", n -> "root supplier");
-        val child = new NodeItem<>("child data", node);
+        val child = Nodes.unnamedChild("child data", node);
         assertThat(child.getName()).isEqualTo("root supplier");
         //when
         child.removeParent();
@@ -990,7 +991,7 @@ public class NodeItemTest {
     public void setNameToNullRevertsToParentNameSupplier() {
         //given
         node = new NodeItem<>(null, n -> "root supplier");
-        val child = new NodeItem<String>(null, "child name", node);
+        val child = Nodes.namedChild("child data", "child name", node);
         assertThat(child.getName()).isEqualTo("child name");
         //when
         child.setName(null);
@@ -1034,8 +1035,8 @@ public class NodeItemTest {
             return "";
         };
         node = new NodeItem<>(null, pathNameSupplier);
-        val child = new NodeItem<String>("child", node);
-        val grandchild = new NodeItem<String>("grandchild", child);
+        val child = Nodes.unnamedChild("child", node);
+        val grandchild = Nodes.unnamedChild("grandchild", child);
         //then
         assertThat(grandchild.getName()).isEqualTo("/child/grandchild");
     }
@@ -1043,8 +1044,8 @@ public class NodeItemTest {
     @Test
     public void canSafelyHandleFindChildWhenAChildHasNoData() {
         //given
-        node = new NodeItem<>(null);
-        new NodeItem<>(null, node);
+        node = Nodes.unnamedRoot(null);
+        Nodes.unnamedChild(null, node);
         //when
         node.findChild("data");
     }

--- a/src/test/java/net/kemitix/node/NodesTest.java
+++ b/src/test/java/net/kemitix/node/NodesTest.java
@@ -1,0 +1,62 @@
+package net.kemitix.node;
+
+import lombok.val;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.Test;
+
+import static net.trajano.commons.testing.UtilityClassTestUtil
+        .assertUtilityClassWellDefined;
+
+/**
+ * Tests for {@link Nodes}.
+ *
+ * @author pcampbell
+ */
+public class NodesTest {
+
+    @Test
+    public void shouldBeValidUtilityClass() throws Exception {
+        assertUtilityClassWellDefined(Nodes.class);
+    }
+
+    @Test
+    public void shouldCreateUnnamedRoot() throws Exception {
+        val node = Nodes.unnamedRoot("data");
+        SoftAssertions softly = new SoftAssertions();
+        softly.assertThat(node.getData()).contains("data");
+        softly.assertThat(node.getName()).isNull();
+        softly.assertAll();
+    }
+
+    @Test
+    public void shouldCreateNamedRoot() throws Exception {
+        val node = Nodes.namedRoot("data", "name");
+        SoftAssertions softly = new SoftAssertions();
+        softly.assertThat(node.getData()).contains("data");
+        softly.assertThat(node.getName()).isEqualTo("name");
+        softly.assertAll();
+    }
+
+    @Test
+    public void shouldCreateUnnamedChild() throws Exception {
+        val parent = Nodes.unnamedRoot("root");
+        val node = Nodes.unnamedChild("data", parent);
+        SoftAssertions softly = new SoftAssertions();
+        softly.assertThat(node.getData()).contains("data");
+        softly.assertThat(node.getName()).isNull();
+        softly.assertThat(node.getParent()).contains(parent);
+        softly.assertAll();
+    }
+
+    @Test
+    public void shouldCreateNamedChild() throws Exception {
+        val parent = Nodes.unnamedRoot("root");
+        val node = Nodes.namedChild("data", "child", parent);
+        SoftAssertions softly = new SoftAssertions();
+        softly.assertThat(node.getData()).contains("data");
+        softly.assertThat(node.getName()).isEqualTo("child");
+        softly.assertThat(node.getParent()).contains(parent);
+        softly.assertAll();
+    }
+
+}


### PR DESCRIPTION
* [BREAKING] Prevents `new NodeItem<>()` - must use `Nodes`
* Adds `Nodes` utility class to provide static constructors
* Remove support for dynamic names
* Minor rewrite of `NodeItem.findChild()` for better handling of `Optional` data