### PR TITLE
Disable JDK 13 test builds

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11, 13 ]
+        java: [ 8, 11 ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java }}


### PR DESCRIPTION
There is a problem with JDK 13 in mutation testing, disabling this until that is resolved.